### PR TITLE
Upgrade prometheus to 2.29.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=2.14.0
+VERSION=2.29.1
 
 BUILD_DIR=$1
 CACHE_DIR=$2


### PR DESCRIPTION
Hi! This PR upgrades Prometheus' version to be 2.29.1.

I was primarily interested in enabling basic auth. The flag `--web.config.file` seems to have been introduced in 2.24.